### PR TITLE
minItems as fn for changing minItems on resize

### DIFF
--- a/js/jquery.elastislide.js
+++ b/js/jquery.elastislide.js
@@ -306,6 +306,16 @@
 		},
 		_validate : function() {
 
+
+  			if( this.options.minItems instanceof Function ) {
+  		  
+  		  		this._minItemsFn = this.options.minItems;
+  		  		this.options.minItems = this.options.minItems( document.documentElement.clientWidth );
+  		
+  			}
+
+
+
 			if( this.options.speed < 0 ) {
 
 				this.options.speed = 500;
@@ -432,6 +442,11 @@
 			var self = this;
 
 			$window.on( 'debouncedresize.elastislide', function() {
+
+				if( self._minItemsFn ) {
+				  self.options.minItems = self._minItemsFn( document.documentElement.clientWidth );
+				}
+
 
 				self._setItemsSize();
 				self._configure();


### PR DESCRIPTION
Alterations allows user to pass in either a number OR function to minItems. 
The function takes one parameter "ww" (window width), and must return 
a number (which becomes the minItems value). 

So it could look like this:

  $('#carousel').elastislide({
      minItems   : function (ww) { return ((ww < 480) ? 3 : (ww < 768) ? 4 : 5); }
  }); 

So if window width is less than 480, minItems is 3, less than 768 its 4 otherwise
minItems is 5. 
