### PR TITLE
Added an option to optionally specify a selector to read the image sizes from

### DIFF
--- a/js/jquery.elastislide.js
+++ b/js/jquery.elastislide.js
@@ -198,6 +198,9 @@
 		// when we resize the window, this will make sure minItems are always shown 
 		// (unless of course minItems is higher than the total number of elements)
 		minItems : 3,
+		// optionally specify a selector rather than using the img element to read the image sizes
+		// (we only use the first matching element within our items)
+		imgSizeItemSelector : 'img',
 		// index of the current item (left most item of the carousel)
 		start : 0,
 		// click item callback
@@ -346,7 +349,7 @@
 			this.$wrapper = this.$carousel.parent().removeClass( 'elastislide-loading' );
 
 			// save original image sizes
-			var $img = this.$items.find( 'img:first' );
+			var $img = this.$items.find( this.options.imgSizeItemSelector ).first();
 			this.imgSize = { width : $img.outerWidth( true ), height : $img.outerHeight( true ) };
 
 			this._setItemsSize();


### PR DESCRIPTION
Added an `imgSizeItemSelector` option to optionally specify a selector rather than using the `img` element to read the image sizes.
### Example

This would use the first matching element with class `fancy-item` within the list to fetch the image sizes from:

``` js
$('#carousel').elastislide({
    imgSizeItemSelector: '.fancy-item'
});
```

``` html
<ul id="carousel" class="elastislide-list">
    <li><div class="fancy-item">Any content</div></li>
    …
</ul>
```
